### PR TITLE
Revert adding tags feature

### DIFF
--- a/roam-with-helm-v2.el
+++ b/roam-with-helm-v2.el
@@ -1,20 +1,5 @@
-;;;;
-(defun node-candidates ()
-  "Returns candidates for the org-roam nodes."
-  (loop for cand in (org-roam-db-query
-                     [:select :distinct [title id node-id tag]
-                              :from nodes
-                              :left-join tags
-                              :on (= tags:node-id nodes:id)])
-        collect (cons (format "%s#%s"
-                              (nth 0 cand)    ;; title 0, id 1
-                                              ;; node-id,2
-                                              ;; tag,3
-                              (nth 3 cand))
-                      cand)))
-
 (defun helm-org-roam (&optional input candidates)
-  "Original see from a blog post by Andrea:
+"Original see from a blog post by Andrea:
 https://ag91.github.io/blog/2022/02/05/an-helm-source-for-org-roam-v2/
 
 The code is almost copied from https://github.com/ag91/escalator.
@@ -31,31 +16,40 @@ hard-coded to be transcluded into the current buffer.
              (helm-build-sync-source "Roam: "
                :must-match nil
                :fuzzy-match t
-               :candidates #'node-candidates
+               :candidates (or candidates (org-roam--get-titles))
                :action
-               '(("Find File" . (lambda (canadidate)
-                                  (org-roam-node-visit
-                                   (org-roam-node-from-title-or-alias
-                                    (nth 0 canadidate))
-                                   nil)))
-                 ("Insert link" . (lambda (canadidate)
-                                    (let ((note-id (org-roam-node-from-title-or-alias (nth 0 canadidate))))
-                                      (insert
-                                       (format
-                                        "[[id:%s][%s]]"
-                                        (org-roam-node-id note-id)
-                                        (org-roam-node-title note-id))))))
-
+               '(("Find File" . (lambda (x)
+                                  (--> x
+                                       org-roam-node-from-title-or-alias
+                                       (org-roam-node-visit it nil))))
+                 ("Insert link" . (lambda (x)
+                                    (--> x
+                                         org-roam-node-from-title-or-alias
+                                         (insert
+                                          (format
+                                           "[[id:%s][%s]]"
+                                           (org-roam-node-id it)
+                                           (org-roam-node-title it))))))
                  ("Insert links with transclusions" . (lambda (x)
-                                                        (let ((note (helm-marked-candidates)))
-                                                          (cl-loop for n in note
-                                                                   do (--> n
-                                                                           (let ((note-id (org-roam-node-from-title-or-alias (nth 0 n))))
-                                                                             (insert
-                                                                              (format
-                                                                               "#+transclude: [[id:%s][%s]] :only-contents\n\n"
-                                                                               (org-roam-node-id note-id)
-                                                                               (org-roam-node-title note-id)))))))))))
+                                       (let ((note (helm-marked-candidates :with-wildcard t)))
+                                         (cl-loop for n in note
+                                                  do (--> n
+                                                          org-roam-node-from-title-or-alias
+                                                          (insert
+                                                           (format
+                                                            "#+transclude: [[id:%s][%s]] :only-contents\n\n"
+                                                            (org-roam-node-id it)
+                                                            (org-roam-node-title it))))))))
+                 ("Follow backlinks" . (lambda (x)
+                                         (let ((candidates
+                                                (--> x
+                                                     org-roam-node-from-title-or-alias
+                                                     org-roam-backlinks-get
+                                                     (--map
+                                                      (org-roam-node-title
+                                                       (org-roam-backlink-source-node it))
+                                                      it))))
+                                           (helm-org-roam nil (or candidates (list x))))))))
              (helm-build-dummy-source
                  "Create note"
                :action '(("Capture note" . (lambda (candidate)


### PR DESCRIPTION
This reverts commit 901ad43c668bd74a724f3bb067a723696616868b.

Adding tags to the query is not an easy task. It makes the problem complicated.

Just use the title to do the quick jumping and preview feature.