### PR TITLE
[elisp] lexical-binding issue

### DIFF
--- a/roam-with-helm-v2.el
+++ b/roam-with-helm-v2.el
@@ -1,4 +1,4 @@
-;;; roam-with-helm --- A source for navigation Org-roam  -*- lexical-binding: t; -*-
+;;; roam-with-helm --- A source for navigation Org-roam  -*- lexical-binding: nil; -*-
 
 ;; Copyright (C) 2022 Ran Wang
 
@@ -133,8 +133,8 @@ very fast.
 "
   (interactive)
   (let ((default (when (use-region-p)
-                     (buffer-substring-no-properties
-                      (region-beginning) (region-end)))))
+                   (buffer-substring-no-properties
+                    (region-beginning) (region-end)))))
     (helm
      :input default
      :sources (list


### PR DESCRIPTION
Not sure what's going on here, but it turns out that by stopping
lexical-binding can walk around this issue:

let: Symbol’s value as variable is void: default

I read a post here: <https://emacs-china.org/t/let/7257/5>

It looks like that lexical-binding is now the default option. It makes
writing elisp function more compact:
<https://emacs-china.org/t/let/7257/6>

The code:

(lambda (canadidate)
  (let ((note-id (org-roam-node-from-id (nth 0 canadidate))))
    (if default
        (progn
          (delete-region (region-beginning) (region-end))
          (insert
           (format
            "[[id:%s][%s]]"
            (org-roam-node-id note-id)
            default)))
      (insert
       (format
        "[[id:%s][%s]]"
        (org-roam-node-id note-id)
        (org-roam-node-title note-id))))))

follows the format like this:

;; -*- lexical-binding: nil; -*-
(lambda ()
  (let ((x 123))
    x))

Notice the lexical-binding: nil

So, to let the Emacs know the existance of `x`, the following format
should be written:

;; -*- lexical-binding: t; -*-
(let ((x 123))
  (lambda ()
    x))

which is the form of `helm-org-roam`

```
let ((default ...

 ...

   (helm ...

         default

```

So the solution is to change the state of the lexical-binding in my
function.

The question remains:

Is that possible to keep lexical-binding and pass `default` to Emacs?